### PR TITLE
feat: Add diagnostic exclusion and duplicate filtering to clang-tidy parser

### DIFF
--- a/clang_tidy_converter/__main__.py
+++ b/clang_tidy_converter/__main__.py
@@ -21,13 +21,16 @@ def create_argparser():
     html = sub.add_parser("html", help="HTML report")
     html.add_argument('-s', '--software_name', default='', help='software name to display in generated report')
 
+    p.add_argument("-e", "--diagnostic_exclude_regex", default=None, help="exclude errors from given warning that match regex")
+    p.add_argument("-d", "--exclude_duplicates", default=False, help="exclude duplicate errors")
+
     sq = sub.add_parser("sq", help="SonarQube JSON")
     sarif = sub.add_parser("sarif", help="SARIF JSON")
 
     return p
 
 def main(args):
-    parser = ClangTidyParser()
+    parser = ClangTidyParser(args.diagnostic_exclude_regex, bool(args.exclude_duplicates))
     messages = parser.parse(sys.stdin.readlines())
 
     if len(args.project_root) > 0:

--- a/tests/test_clang_tidy_parser.py
+++ b/tests/test_clang_tidy_parser.py
@@ -19,6 +19,116 @@ class ClangTidyParserTest(unittest.TestCase):
         self.assertEqual([], msg.details_lines)
         self.assertEqual([], msg.children)
 
+    def test_warning_multiple_same_messages(self):
+        parser = ClangTidyParser(exclude_duplicates=True)
+        messages = parser.parse([
+            '/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+            '/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]'])
+        self.assertEqual(1, len(messages))
+        msg = messages[0]
+        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
+        self.assertEqual(1039, msg.line)
+        self.assertEqual(3, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+    
+    def test_warning_multiple_different_messages(self):
+        parser = ClangTidyParser(exclude_duplicates=True)
+        messages = parser.parse([
+            '/usr/lib/include/some_include.h:1038:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+            '/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+            '/usr/lib/include/some_include.h:1039:4: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+            '/usr/lib/include/some_include2.h:1039:4: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+            '/usr/lib/include/some_include.h:1039:4: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks2]'])
+        self.assertEqual(5, len(messages))
+        msg = messages[0]
+        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
+        self.assertEqual(1038, msg.line)
+        self.assertEqual(3, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+        msg = messages[1]
+        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
+        self.assertEqual(1039, msg.line)
+        self.assertEqual(3, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+        msg = messages[2]
+        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
+        self.assertEqual(1039, msg.line)
+        self.assertEqual(4, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+        msg = messages[3]
+        self.assertEqual('/usr/lib/include/some_include2.h', msg.filepath)
+        self.assertEqual(1039, msg.line)
+        self.assertEqual(4, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+        msg = messages[4]
+        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
+        self.assertEqual(1039, msg.line)
+        self.assertEqual(4, msg.column)
+        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
+        self.assertEqual('clang-analyzer-cplusplus.NewDeleteLeaks2', msg.diagnostic_name)
+
+    def test_diagnostic_exclude_regex_exact_match(self):
+        parser = ClangTidyParser(diagnostic_exclude_regex="clang-analyzer-cplusplus.NewDeleteLeaks")
+        messages = parser.parse([
+            '/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]'
+		])
+        self.assertEqual(1, len(messages))
+        msg = messages[0]
+        self.assertEqual('clang-analyzer-core.NullDereference', msg.diagnostic_name)
+
+    def test_diagnostic_exclude_regex_partial_match(self): 
+        parser = ClangTidyParser(diagnostic_exclude_regex="NewDelete") 
+        messages = parser.parse([ 
+			'/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]', 
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]' 
+		]) 
+        self.assertEqual(1, len(messages)) 
+        msg = messages[0] 
+        self.assertEqual('clang-analyzer-core.NullDereference', msg.diagnostic_name)
+
+    def test_diagnostic_exclude_regex_multiple_patterns(self):
+        parser = ClangTidyParser(diagnostic_exclude_regex="NewDelete|NullDereference")
+        messages = parser.parse([
+			'/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]',
+			'/usr/lib/include/some_include.h:1041:3: warning: Some different issue [modernize-use-nullptr]'
+		])
+        self.assertEqual(1, len(messages))
+        self.assertEqual('modernize-use-nullptr', messages[0].diagnostic_name)
+
+    def test_diagnostic_exclude_regex_no_match(self):
+        parser = ClangTidyParser(diagnostic_exclude_regex="non-existent-diagnostic")
+        messages = parser.parse([
+			'/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]'
+		])
+        self.assertEqual(2, len(messages))
+        self.assertEqual('clang-analyzer-cplusplus.NewDeleteLeaks', messages[0].diagnostic_name)
+        self.assertEqual('clang-analyzer-core.NullDereference', messages[1].diagnostic_name)
+
+    def test_diagnostic_exclude_regex_with_no_diagnostic_name(self):
+        parser = ClangTidyParser(diagnostic_exclude_regex=".*")
+        messages = parser.parse([
+			'/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak',  # No diagnostic name
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]'
+		])
+        self.assertEqual(1, len(messages))
+        msg = messages[0]
+        self.assertEqual('', msg.diagnostic_name)  # Empty diagnostic name
+
+    def test_diagnostic_exclude_regex_with_exclude_duplicates(self):
+        parser = ClangTidyParser(diagnostic_exclude_regex="NewDelete", exclude_duplicates=True)
+        messages = parser.parse([
+			'/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]',
+			'/usr/lib/include/some_include.h:1040:3: warning: Some other issue [clang-analyzer-core.NullDereference]',  # Duplicate
+			'/usr/lib/include/some_include.h:1041:3: warning: Another memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]'  # Should be excluded by regex
+		])
+        self.assertEqual(1, len(messages))
+        msg = messages[0]
+        self.assertEqual('clang-analyzer-core.NullDereference', msg.diagnostic_name)
+
     def test_remark_message_level(self):
         parser = ClangTidyParser()
         messages = parser.parse(['/usr/lib/include/some_include.h:1039:3: remark: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]'])
@@ -61,36 +171,6 @@ class ClangTidyParserTest(unittest.TestCase):
         self.assertEqual(['  return new SomeFunction(',
                           '  ^'], msg.details_lines)
         self.assertEqual([], msg.children)
-
-    def test_warning_message_children(self):
-        parser = ClangTidyParser()
-        messages = parser.parse(['/usr/lib/include/some_include.h:1039:3: warning: Potential memory leak [clang-analyzer-cplusplus.NewDeleteLeaks]',
-                                 '  return new SomeFunction(',
-                                 '  ^',
-                                 '/home/user/some_source.cpp:267:15: note: Calling \'OtherFunction\'',
-                                 '    auto sf = OtherFunction( a, b, c );',
-                                 '              ^'])
-        self.assertEqual(1, len(messages))
-        msg = messages[0]
-        self.assertEqual('/usr/lib/include/some_include.h', msg.filepath)
-        self.assertEqual(1039, msg.line)
-        self.assertEqual(3, msg.column)
-        self.assertEqual(ClangMessage.Level.WARNING, msg.level)
-        self.assertEqual('Potential memory leak', msg.message)
-        self.assertEqual('clang-analyzer-cplusplus.NewDeleteLeaks', msg.diagnostic_name)
-        self.assertEqual(['  return new SomeFunction(',
-                          '  ^'], msg.details_lines)
-        self.assertEqual(1, len(msg.children))
-        child = msg.children[0]
-        self.assertEqual('/home/user/some_source.cpp', child.filepath)
-        self.assertEqual(267, child.line)
-        self.assertEqual(15, child.column)
-        self.assertEqual(ClangMessage.Level.NOTE, child.level)
-        self.assertEqual('Calling \'OtherFunction\'', child.message)
-        self.assertEqual('', child.diagnostic_name)
-        self.assertEqual(['    auto sf = OtherFunction( a, b, c );',
-                          '              ^'], child.details_lines)
-        self.assertEqual([], child.children)
 
     def test_ignorance_of_generic_errors(self):
         parser = ClangTidyParser()


### PR DESCRIPTION
This commit introduces two new features to the clang-tidy parser:

-   Diagnostic exclusion: A regular expression can be provided to exclude specific diagnostics from the parsed messages. This is useful for filtering out unwanted or irrelevant warnings.
-   Duplicate filtering: A flag can be enabled to exclude duplicate messages from the parsed output. This helps to reduce noise and focus on unique issues.

These features are implemented by:

-   Adding `diagnostic_exclude_regex` and `exclude_duplicates` parameters to the `ClangTidyParser` constructor.
-   Filtering messages based on the provided regex in the `_parse_message` method.
-   Tracking seen messages using a set in the `parse` method to exclude duplicates.
-   Adding command-line arguments `-e` / `--diagnostic_exclude_regex` and `-d` / `--exclude_duplicates` to control these features.
-   Adding new unit tests to verify the correct behavior of the new features.